### PR TITLE
Add sync flag to delete resources for removed files

### DIFF
--- a/.github/workflows/apply_on_merge.yaml
+++ b/.github/workflows/apply_on_merge.yaml
@@ -23,4 +23,4 @@ jobs:
       - name: Apply changed manifests
         run: |
           set -euo pipefail
-          tfy apply -d truefoundry --diffs-only --ref "${{ github.event.before }}"
+          tfy apply -d truefoundry --diffs-only --sync --ref "${{ github.event.before }}"

--- a/.github/workflows/dry_run_on_pr.yaml
+++ b/.github/workflows/dry_run_on_pr.yaml
@@ -23,4 +23,4 @@ jobs:
         run: |
           set -euo pipefail
           BASE_REF="origin/${{ github.base_ref }}"
-          tfy apply -d truefoundry --dry-run --show-diff --diffs-only --ref "$BASE_REF"
+          tfy apply -d truefoundry --dry-run --show-diff --diffs-only --sync --ref "$BASE_REF"

--- a/README.md
+++ b/README.md
@@ -92,14 +92,14 @@ Workflows (`.github/workflows/`):
 
 - **When:** `pull_request` — `opened`, `synchronize`.
 - **What it does:** Installs the TrueFoundry CLI and runs:
-  - `tfy apply -d truefoundry --dry-run --show-diff --diffs-only --ref origin/<base_branch>`
+  - `tfy apply -d truefoundry --dry-run --show-diff --diffs-only --sync --ref origin/<base_branch>`
 - **Meaning:** Only manifests that **differ from the PR base branch** are simulated; output includes diffs. No separate YAML/name validation step — invalid manifests surface as CLI errors.
 
 ### 2. `apply_on_merge.yaml`
 
 - **When:** `push` to **`main`**.
 - **What it does:**
-  - `tfy apply -d truefoundry --diffs-only --ref "${{ github.event.before }}"`
+  - `tfy apply -d truefoundry --diffs-only --sync --ref "${{ github.event.before }}"`
 - **Meaning:** Applies only what changed in **that push** relative to the previous tip of `main` (typical merge or direct push).
 
 > **Note:** Workflows must exist on the **default branch** for PR-triggered jobs to run. First-time workflow PRs need that file merged (or present) on the default branch.
@@ -112,8 +112,8 @@ Workflows (`.github/workflows/`):
 
 | Pipeline | When | Command |
 |----------|------|--------|
-| **TFY dry-run** | Pull requests | `tfy apply -d truefoundry --dry-run --show-diff --diffs-only --ref "$BITBUCKET_PR_DESTINATION_COMMIT"` |
-| **TFY apply** | Push to **main** | `tfy apply -d truefoundry --diffs-only --ref "HEAD^"` |
+| **TFY dry-run** | Pull requests | `tfy apply -d truefoundry --dry-run --show-diff --diffs-only --sync --ref "$BITBUCKET_PR_DESTINATION_COMMIT"` |
+| **TFY apply** | Push to **main** | `tfy apply -d truefoundry --diffs-only --sync --ref "HEAD^"` |
 
 Set secured variables **`TFY_API_KEY`** and **`TFY_HOST`**. The pipeline removes **`bitbucket-pipelines.yml`** before apply so the pipeline file is not treated as a manifest.
 

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -11,7 +11,7 @@ pipelines:
             - apt-get update && apt-get install -y git
             - pip install -U "truefoundry"
             - rm -f bitbucket-pipelines.yml
-            - tfy apply -d truefoundry --dry-run --show-diff --diffs-only --ref "${BITBUCKET_PR_DESTINATION_COMMIT}"
+            - tfy apply -d truefoundry --dry-run --show-diff --diffs-only --sync --ref "${BITBUCKET_PR_DESTINATION_COMMIT}"
 
   branches:
     main:
@@ -21,4 +21,4 @@ pipelines:
             - apt-get update && apt-get install -y git
             - pip install -U "truefoundry"
             - rm -f bitbucket-pipelines.yml
-            - tfy apply -d truefoundry --diffs-only --ref "HEAD^"
+            - tfy apply -d truefoundry --diffs-only --sync --ref "HEAD^"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Enabling `--sync` can delete previously-applied resources when manifests are removed/renamed, so mis-scoped directories or refs could cause unintended deletions. Change is limited to CI command flags and documentation updates.
> 
> **Overview**
> Updates GitHub Actions and Bitbucket Pipelines to run `tfy apply` with the `--sync` flag for both PR dry-runs and `main` applies, so removed manifests are reconciled (deleted) during sync.
> 
> Refreshes the README examples to match the new CI commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32d7391eef2b7c125ff570cc536d7c215faf7600. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->