### PR TITLE
Update directory option to --dir in tfy apply

### DIFF
--- a/.github/workflows/apply_on_merge.yaml
+++ b/.github/workflows/apply_on_merge.yaml
@@ -23,4 +23,4 @@ jobs:
       - name: Apply changed manifests
         run: |
           set -euo pipefail
-          tfy apply -dir truefoundry --diffs-only --sync --ref "${{ github.event.before }}"
+          tfy apply --dir truefoundry --diffs-only --sync --ref "${{ github.event.before }}"

--- a/.github/workflows/apply_on_merge.yaml
+++ b/.github/workflows/apply_on_merge.yaml
@@ -23,4 +23,4 @@ jobs:
       - name: Apply changed manifests
         run: |
           set -euo pipefail
-          tfy apply -d truefoundry --diffs-only --ref "${{ github.event.before }}"
+          tfy apply --dir truefoundry --diffs-only --ref "${{ github.event.before }}"

--- a/.github/workflows/dry_run_on_pr.yaml
+++ b/.github/workflows/dry_run_on_pr.yaml
@@ -23,4 +23,4 @@ jobs:
         run: |
           set -euo pipefail
           BASE_REF="origin/${{ github.base_ref }}"
-          tfy apply -d truefoundry --dry-run --show-diff --diffs-only --ref "$BASE_REF"
+          tfy apply --dir truefoundry --dry-run --show-diff --diffs-only --ref "$BASE_REF"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Sample repo for TrueFoundry GitOps: cluster, workspace, application, gateway, and access configuration in one place. CI runs **`tfy apply`** in dry-run on pull requests and applies changes when you merge (or push) to **`main`**.
 
-All manifests live under **`truefoundry/`** so a single directory can be passed to the CLI (`tfy apply -d truefoundry`).
+All manifests live under **`truefoundry/`** so a single directory can be passed to the CLI (`tfy apply --dir truefoundry`).
 
 ## Folder structure
 
@@ -92,14 +92,14 @@ Workflows (`.github/workflows/`):
 
 - **When:** `pull_request` — `opened`, `synchronize`.
 - **What it does:** Installs the TrueFoundry CLI and runs:
-  - `tfy apply -d truefoundry --dry-run --show-diff --diffs-only --ref origin/<base_branch>`
+  - `tfy apply --dir truefoundry --dry-run --show-diff --diffs-only --ref origin/<base_branch>`
 - **Meaning:** Only manifests that **differ from the PR base branch** are simulated; output includes diffs. No separate YAML/name validation step — invalid manifests surface as CLI errors.
 
 ### 2. `apply_on_merge.yaml`
 
 - **When:** `push` to **`main`**.
 - **What it does:**
-  - `tfy apply -d truefoundry --diffs-only --ref "${{ github.event.before }}"`
+  - `tfy apply --dir truefoundry --diffs-only --ref "${{ github.event.before }}"`
 - **Meaning:** Applies only what changed in **that push** relative to the previous tip of `main` (typical merge or direct push).
 
 > **Note:** Workflows must exist on the **default branch** for PR-triggered jobs to run. First-time workflow PRs need that file merged (or present) on the default branch.
@@ -112,8 +112,8 @@ Workflows (`.github/workflows/`):
 
 | Pipeline | When | Command |
 |----------|------|--------|
-| **TFY dry-run** | Pull requests | `tfy apply -d truefoundry --dry-run --show-diff --diffs-only --ref "$BITBUCKET_PR_DESTINATION_COMMIT"` |
-| **TFY apply** | Push to **main** | `tfy apply -d truefoundry --diffs-only --ref "HEAD^"` |
+| **TFY dry-run** | Pull requests | `tfy apply --dir truefoundry --dry-run --show-diff --diffs-only --ref "$BITBUCKET_PR_DESTINATION_COMMIT"` |
+| **TFY apply** | Push to **main** | `tfy apply --dir truefoundry --diffs-only --ref "HEAD^"` |
 
 Set secured variables **`TFY_API_KEY`** and **`TFY_HOST`**. The pipeline removes **`bitbucket-pipelines.yml`** before apply so the pipeline file is not treated as a manifest.
 
@@ -127,10 +127,10 @@ export TFY_HOST=...
 export TFY_API_KEY=...
 
 # Dry-run entire tree vs current branch tip
-tfy apply -d truefoundry --dry-run --show-diff
+tfy apply --dir truefoundry --dry-run --show-diff
 
 # Apply everything under truefoundry (no git diff filter)
-tfy apply -d truefoundry
+tfy apply --dir truefoundry
 ```
 
 Use **`--diffs-only`** and **`--ref <commit>`** when you only want changed files (same as CI).

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,5 +1,5 @@
 # Secured repo variables: TFY_API_KEY, TFY_HOST
-# tfy apply -d . includes nested dirs; rm CI YAML so TFY does not load pipelines/workflows.
+# tfy apply --dir . includes nested dirs; rm CI YAML so TFY does not load pipelines/workflows.
 image: python:3.8
 
 pipelines:
@@ -11,7 +11,7 @@ pipelines:
             - apt-get update && apt-get install -y git
             - pip install -U "truefoundry"
             - rm -f bitbucket-pipelines.yml
-            - tfy apply -d truefoundry --dry-run --show-diff --diffs-only --ref "${BITBUCKET_PR_DESTINATION_COMMIT}"
+            - tfy apply --dir truefoundry --dry-run --show-diff --diffs-only --ref "${BITBUCKET_PR_DESTINATION_COMMIT}"
 
   branches:
     main:
@@ -21,4 +21,4 @@ pipelines:
             - apt-get update && apt-get install -y git
             - pip install -U "truefoundry"
             - rm -f bitbucket-pipelines.yml
-            - tfy apply -d truefoundry --diffs-only --ref "HEAD^"
+            - tfy apply --dir truefoundry --diffs-only --ref "HEAD^"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a straightforward CI/doc update swapping a CLI flag; the main risk is CI breakage if the installed `truefoundry` CLI version doesn’t support `--dir`.
> 
> **Overview**
> Updates GitHub Actions and Bitbucket Pipelines to use `tfy apply --dir truefoundry` instead of `-d truefoundry` for both PR dry-runs and main-branch applies.
> 
> Aligns README and pipeline comments/examples with the new `--dir` flag so CI and local usage documentation match the updated command syntax.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b936c844691e27cc88194a96326128f395335b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->